### PR TITLE
Provide more entropy by default

### DIFF
--- a/10.x/CHANGELOG.md
+++ b/10.x/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Releases
 
+## 10.0.rc2-2
+
+* Provide `haveged` by default, to have more entropy when a new VM starts.
+
+
 ## 10.0.rc2-1
 
 * Based of Debian Buster RC2

--- a/10.x/Makefile
+++ b/10.x/Makefile
@@ -1,7 +1,7 @@
 PACKER_FILE = packer.json
 
 OUTPUT_DIR = output
-OUTPUT_NAME = debian-10.0.rc2-1.qcow2
+OUTPUT_NAME = debian-10.0.rc2-2.qcow2
 OUTPUT = $(OUTPUT_DIR)/$(OUTPUT_NAME)
 
 PACKER_FLAGS = -var output_dir="$(OUTPUT_DIR)" -var output_name="$(OUTPUT_NAME)"

--- a/10.x/http/preseed.cfg
+++ b/10.x/http/preseed.cfg
@@ -276,7 +276,9 @@ tasksel tasksel/first multiselect SSH server
 
 # Individual additional packages to install
 # We need at least these to continue the preseeding later on.
-d-i pkgsel/include string openssh-server sudo
+# Provide also haveged so we (hopefully) have more entropy when our VM starts
+# for the first time.
+d-i pkgsel/include string haveged openssh-server sudo
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade


### PR DESCRIPTION
The current version lacks entropy at startup, which blocks several
processes at boot time, such as SSH or cloud-init (when it tries to
generate SSH host key for the first boot).

`haveged` is already provided inside the Debian installer (see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923675) and although
it's not perfect, it helps when instanciating new VM from the template
after that.

In case users need a more advanced random number generator, they should
install the rngd daemon (which can be installed beside haveged) and
provide a hardware number generator when booting up the image with KVM
(see https://wiki.qemu.org/Features/VirtIORNG).